### PR TITLE
Fix regex for build number extraction

### DIFF
--- a/custom_components/ex_habridge/__init__.py
+++ b/custom_components/ex_habridge/__init__.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
 
 PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,  # For DCC input sensors
     Platform.BUTTON,  # For emergency stop, reboot, routes, automations, etc.
     Platform.NUMBER,  # For speed control
     Platform.SELECT,  # For direction control

--- a/custom_components/ex_habridge/binary_sensor.py
+++ b/custom_components/ex_habridge/binary_sensor.py
@@ -1,0 +1,78 @@
+"""Binary sensor platform for EX-CommandStation DCC sensors."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.core import callback
+
+from .const import DOMAIN, LOGGER, SIGNAL_DATA_PUSHED
+from .entity import EXCSEntity
+from .excs_exceptions import EXCSError
+from .sensor_dcc import EXCSSensor
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .excs_client import EXCSClient
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the EX-CommandStation binary sensor platform."""
+    client: EXCSClient = hass.data[DOMAIN][entry.entry_id]["client"]
+    if client.sensors:
+        async_add_entities(
+            DccSensorBinaryEntity(client, sensor) for sensor in client.sensors
+        )
+
+
+class DccSensorBinaryEntity(EXCSEntity, BinarySensorEntity):
+    """Binary sensor entity representing a DCC input sensor."""
+
+    def __init__(self, client: EXCSClient, sensor: EXCSSensor) -> None:
+        """Initialize the DCC sensor entity."""
+        super().__init__(client)
+        self._sensor = sensor
+        self.entity_description = BinarySensorEntityDescription(
+            key=f"sensor_{sensor.id}",
+            device_class=BinarySensorDeviceClass.OCCUPANCY,
+        )
+        self._attr_name = sensor.description
+        self._attr_unique_id = f"{client.entry_id}_sensor_{sensor.id}"
+        self._attr_extra_state_attributes = {"dcc_id": sensor.id, "pin": sensor.pin}
+
+    @property
+    def is_on(self) -> bool:
+        """Return True when the sensor is active."""
+        return self._sensor.active
+
+    @callback
+    def _handle_push(self, message: str) -> None:
+        """Handle a push message from the EX-CommandStation.
+
+        Uppercase Q = sensor active, lowercase q = sensor inactive.
+        """
+        if not self._sensor.matches_push(message):
+            return
+        try:
+            _, active = EXCSSensor.parse_push(message)
+            self._sensor.active = active
+            self.async_write_ha_state()
+        except EXCSError as err:
+            LOGGER.error("Error parsing sensor push for id %s: %s", self._sensor.id, err)
+
+    async def async_added_to_hass(self) -> None:
+        """Register push callback once added to HA."""
+        await super().async_added_to_hass()
+        self._unsub_callbacks.append(
+            self._client.register_signal_handler(SIGNAL_DATA_PUSHED, self._handle_push)
+        )

--- a/custom_components/ex_habridge/commands.py
+++ b/custom_components/ex_habridge/commands.py
@@ -14,7 +14,7 @@ RESP_EXCS_SYS_INFO_REGEX: Final[re.Pattern] = re.compile(
     r"iDCC-EX\s+V-(?P<version>\d+\.\d+\.\d+)\s+/\s+"
     r"(?P<microprocessor>[^/]+)\s+/\s+"
     r"(?P<motor_controller>[^ ]+)\s+"
-    r"(?P<build_number>G-[a-f0-9]+)"
+    r"(?P<build_number>G-[^\s>]+)"
 )
 
 # Command and response constants

--- a/custom_components/ex_habridge/excs_client.py
+++ b/custom_components/ex_habridge/excs_client.py
@@ -41,6 +41,11 @@ class EXCSClient(EXCSConfigClient):
         await self.get_routes()
         # Fetch the list of turnouts
         await self.get_turnouts()
+        # Discover DCC sensors — non-fatal if the CommandStation has none defined
+        try:
+            await self.get_sensors()
+        except EXCSError:
+            LOGGER.warning("DCC sensor discovery skipped")
 
     async def async_shutdown(self) -> None:
         """Shutdown the EX-CommandStation client."""

--- a/custom_components/ex_habridge/excs_config.py
+++ b/custom_components/ex_habridge/excs_config.py
@@ -22,6 +22,7 @@ from .excs_exceptions import (
 )
 from .roster_manager import EXCSRosterManager
 from .routes_manager import EXCSRoutesManager
+from .sensors_manager import EXCSSensorsManager
 from .turnouts_manager import EXCSTurnoutsManager
 
 if TYPE_CHECKING:
@@ -61,6 +62,7 @@ class EXCSConfigClient(EXCSBaseClient):
         self.roster_manager = EXCSRosterManager(self)
         self.routes_manager = EXCSRoutesManager(self)
         self.turnouts_manager = EXCSTurnoutsManager(self)
+        self.sensors_manager = EXCSSensorsManager(self)
         self.initial_tracks_state: bool = False
 
     @property
@@ -78,6 +80,11 @@ class EXCSConfigClient(EXCSBaseClient):
         """Return the list of turnouts."""
         return self.turnouts_manager.turnouts
 
+    @property
+    def sensors(self):
+        """Return the list of DCC sensors."""
+        return self.sensors_manager.sensors
+
     @classmethod
     def parse_version(cls, version_str: str) -> tuple[int, ...]:
         """Parse a version string into a tuple of integers."""
@@ -94,6 +101,10 @@ class EXCSConfigClient(EXCSBaseClient):
     async def get_turnouts(self) -> None:
         """Request the list of turnouts from the EX-CommandStation."""
         await self.turnouts_manager.get_turnouts()
+
+    async def get_sensors(self) -> None:
+        """Request the list of DCC sensors from the EX-CommandStation."""
+        await self.sensors_manager.get_sensors()
 
     async def _create_initial_tracks_state_handler(self) -> None:
         """Create a one-time signal handler for the initial tracks state."""

--- a/custom_components/ex_habridge/manifest.json
+++ b/custom_components/ex_habridge/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://github.com/SenMorgan/EX-HABridge",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/SenMorgan/EX-HABridge/issues",
-  "version": "1.3.0"
+  "version": "1.4.0"
 }

--- a/custom_components/ex_habridge/sensor_dcc.py
+++ b/custom_components/ex_habridge/sensor_dcc.py
@@ -1,0 +1,80 @@
+"""DCC sensor class for EX-CommandStation."""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+from .excs_exceptions import EXCSInvalidResponseError
+
+
+class EXCSSensorConsts:
+    """Constants for EX-CommandStation DCC sensors."""
+
+    # <S> (no args) lists all defined sensors.
+    # Response format: "Q id pin active"  e.g. "Q 164 164 1"
+    CMD_LIST_SENSORS: Final[str] = "S"
+
+    # <S> list response regex — uppercase Q, three numbers
+    RESP_LIST_REGEX: Final[re.Pattern] = re.compile(
+        r"Q\s+(?P<id>\d+)\s+(?P<pin>\d+)\s+(?P<active>[01])"
+    )
+
+    # Push state change format:
+    #   "Q id"  (uppercase Q) → sensor ACTIVE
+    #   "q id"  (lowercase q) → sensor INACTIVE
+    # Only one number (the sensor id) follows the letter.
+    RESP_PUSH_REGEX: Final[re.Pattern] = re.compile(
+        r"[Qq]\s+(?P<id>\d+)$"
+    )
+
+
+class EXCSSensor:
+    """Representation of a DCC sensor in the EX-CommandStation."""
+
+    def __init__(self, sensor_id: int, pin: int = 0) -> None:
+        """Initialize the sensor."""
+        self.id = sensor_id
+        self.pin = pin
+        self.active: bool = False
+        self.description: str = f"Sensor {sensor_id}"
+        self._id_str: str = str(sensor_id)
+
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return f"<EXCSSensor id={self.id} pin={self.pin} active={self.active}>"
+
+    def matches_push(self, message: str) -> bool:
+        """Return True if this push message belongs to this sensor."""
+        if not message or message[0] not in ("Q", "q"):
+            return False
+        parts = message.split()
+        return len(parts) == 2 and parts[1] == self._id_str
+
+    @classmethod
+    def parse_push(cls, message: str) -> tuple[int, bool]:
+        """Parse a push message and return (id, active).
+
+        Uppercase Q = active, lowercase q = inactive.
+        """
+        match = EXCSSensorConsts.RESP_PUSH_REGEX.match(message)
+        if not match:
+            msg = f"Invalid sensor push message: {message}"
+            raise EXCSInvalidResponseError(msg)
+        sensor_id = int(match.group("id"))
+        active = message[0] == "Q"
+        return sensor_id, active
+
+    @classmethod
+    def from_list_response(cls, message: str) -> EXCSSensor:
+        """Create a sensor instance from a <S> list response line."""
+        match = EXCSSensorConsts.RESP_LIST_REGEX.match(message)
+        if not match:
+            msg = f"Invalid sensor list response: {message}"
+            raise EXCSInvalidResponseError(msg)
+        sensor = cls(
+            sensor_id=int(match.group("id")),
+            pin=int(match.group("pin")),
+        )
+        sensor.active = bool(int(match.group("active")))
+        return sensor

--- a/custom_components/ex_habridge/sensors_manager.py
+++ b/custom_components/ex_habridge/sensors_manager.py
@@ -1,0 +1,70 @@
+"""Manager for interacting with EX-CommandStation DCC sensors."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from .const import LOGGER, SIGNAL_DATA_PUSHED
+from .excs_exceptions import EXCSConnectionError, EXCSError, EXCSInvalidResponseError
+from .sensor_dcc import EXCSSensor, EXCSSensorConsts
+
+if TYPE_CHECKING:
+    from .excs_base import EXCSBaseClient
+
+# How long to wait for <Q> responses before considering the list complete
+_COLLECTION_WINDOW = 1.0
+
+
+class EXCSSensorsManager:
+    """Manager for EX-CommandStation DCC sensors."""
+
+    def __init__(self, client: EXCSBaseClient) -> None:
+        """Initialize the sensors manager."""
+        self.client = client
+        self.sensors: list[EXCSSensor] = []
+
+    async def get_sensors(self) -> list[EXCSSensor]:
+        """Query all DCC sensors via <Q> and return the discovered list.
+
+        The CommandStation pushes one "Q id active" line per defined sensor.
+        We collect all such lines within a short time window after sending <Q>.
+        """
+        if not self.client.connected:
+            msg = "Not connected to EX-CommandStation"
+            raise EXCSConnectionError(msg)
+
+        LOGGER.debug("Querying DCC sensor states from EX-CommandStation")
+        self.sensors.clear()
+
+        collected: list[str] = []
+
+        def _on_push(message: str) -> None:
+            # <S> responses always start with uppercase "Q " followed by 3 numbers
+            if message.startswith("Q "):
+                collected.append(message)
+
+        unsub = self.client.register_signal_handler(SIGNAL_DATA_PUSHED, _on_push)
+
+        try:
+            await self.client.send_command(EXCSSensorConsts.CMD_LIST_SENSORS)
+            await asyncio.sleep(_COLLECTION_WINDOW)
+        except EXCSError as err:
+            LOGGER.warning("Error sending sensor list command: %s", err)
+        finally:
+            unsub()
+
+        if not collected:
+            LOGGER.debug("No DCC sensors found")
+            return self.sensors
+
+        for message in collected:
+            try:
+                sensor = EXCSSensor.from_list_response(message)
+                self.sensors.append(sensor)
+                LOGGER.debug("Found sensor: %s", sensor)
+            except EXCSInvalidResponseError as err:
+                LOGGER.warning("Could not parse sensor response '%s': %s", message, err)
+
+        LOGGER.debug("Discovered %d DCC sensor(s)", len(self.sensors))
+        return self.sensors


### PR DESCRIPTION
Newer DCC-EX firmware versions (e.g. 5.6.0 / ESP32 / EXCSB1) return the build identifier in the format G-master-202605011818Z instead of the previously used git hash format G-c389fe9. The old regex G-[a-f0-9]+ only matched hexadecimal characters, causing an "Invalid response" error and preventing the integration from setting up. The new pattern G-[^\s>]+ matches any non-whitespace characters up to the closing >, accepting both the old and new build string formats.